### PR TITLE
Fix various lints

### DIFF
--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -57,18 +57,18 @@ fn pre_resolve_locations(dict: &profiles::ProfilesDictionary, store: &SymbolStor
             let frame_tag = resolve_frame_type(location, dict);
             if location.lines.is_empty() {
                 // Try native symbolication
-                if frame_tag == "Native" {
-                    if let Some(names) = symbolize_native(store, location, dict) {
-                        // Join inlined native frames into one string for the cache
-                        return names
-                            .iter()
-                            .enumerate()
-                            .map(|(i, n)| {
-                                format!("{} [Native]{}", n, if i > 0 { " [Inline]" } else { "" })
-                            })
-                            .collect::<Vec<_>>()
-                            .join(" / ");
-                    }
+                if frame_tag == "Native"
+                    && let Some(names) = symbolize_native(store, location, dict)
+                {
+                    // Join inlined native frames into one string for the cache
+                    return names
+                        .iter()
+                        .enumerate()
+                        .map(|(i, n)| {
+                            format!("{} [Native]{}", n, if i > 0 { " [Inline]" } else { "" })
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" / ");
                 }
                 format_with_tag(&resolve_unsymbolized_label(location, dict), &frame_tag)
             } else {
@@ -150,7 +150,7 @@ fn process_export(
                             1
                         };
 
-                        flamegraph.add_stack(&stack, value);
+                        flamegraph.add_stack(stack, value);
                         sample_count += value as u64;
                     }
                 }
@@ -274,23 +274,23 @@ fn resolve_frame_type(
         if dict.string_table[key_idx] != "profile.frame.type" {
             continue;
         }
-        if let Some(ref value) = attr.value {
-            if let Some(common::any_value::Value::StringValue(ref s)) = value.value {
-                return match s.as_str() {
-                    "native" => "Native".to_string(),
-                    "kernel" => "Kernel".to_string(),
-                    "jvm" => "JVM".to_string(),
-                    "cpython" => "Python".to_string(),
-                    "php" | "phpjit" => "PHP".to_string(),
-                    "ruby" => "Ruby".to_string(),
-                    "perl" => "Perl".to_string(),
-                    "v8js" => "JS".to_string(),
-                    "dotnet" => ".NET".to_string(),
-                    "beam" => "Beam".to_string(),
-                    "go" => "Go".to_string(),
-                    other => other.to_string(),
-                };
-            }
+        if let Some(ref value) = attr.value
+            && let Some(common::any_value::Value::StringValue(ref s)) = value.value
+        {
+            return match s.as_str() {
+                "native" => "Native".to_string(),
+                "kernel" => "Kernel".to_string(),
+                "jvm" => "JVM".to_string(),
+                "cpython" => "Python".to_string(),
+                "php" | "phpjit" => "PHP".to_string(),
+                "ruby" => "Ruby".to_string(),
+                "perl" => "Perl".to_string(),
+                "v8js" => "JS".to_string(),
+                "dotnet" => ".NET".to_string(),
+                "beam" => "Beam".to_string(),
+                "go" => "Go".to_string(),
+                other => other.to_string(),
+            };
         }
     }
     String::from("Unknown")
@@ -316,14 +316,12 @@ fn resolve_thread_name(sample: &profiles::Sample, dict: &profiles::ProfilesDicti
             continue;
         }
         let key = &dict.string_table[key_idx];
-        if key == "thread.name" {
-            if let Some(ref value) = attr.value {
-                if let Some(common::any_value::Value::StringValue(ref s)) = value.value {
-                    if !s.is_empty() {
-                        return s.clone();
-                    }
-                }
-            }
+        if key == "thread.name"
+            && let Some(ref value) = attr.value
+            && let Some(common::any_value::Value::StringValue(ref s)) = value.value
+            && !s.is_empty()
+        {
+            return s.clone();
         }
     }
     "[unknown]".to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
                                 info: symbolizer::extract_symbols(&path).and_then(|file_sym| {
                                     let info = storage::ExecutableInfo {
                                         file_id: file_sym.file_id,
-                                        file_name: file_name,
+                                        file_name,
                                         num_ranges: file_sym.ranges.len() as u32,
                                     };
                                     store.store_file_symbols(&file_sym, &path)?;
@@ -114,10 +114,10 @@ fn main() -> Result<()> {
                         let sender = tui.events.sender.clone();
                         let store = Arc::clone(&store);
                         move || {
-                            sender.send(Event::SymbolsRemoved {
-                                name: name,
+                            Box::new(sender.send(Event::SymbolsRemoved {
+                                name,
                                 error: store.remove_file_symbols(file_id).err(),
-                            })
+                            }))
                         }
                     });
                 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,6 @@
+use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
-use ratatui::Terminal;
 use state::State;
 use std::{io, panic};
 

--- a/src/tui/state/executables.rs
+++ b/src/tui/state/executables.rs
@@ -155,10 +155,10 @@ impl ExecutablesTab {
                 }
             }
             KeyCode::Char('r') => {
-                if let Some(entry) = self.list.get(self.cursor) {
-                    if let Some(file_id) = entry.file_id {
-                        return Action::RemoveSymbols(entry.name.clone(), file_id);
-                    }
+                if let Some(entry) = self.list.get(self.cursor)
+                    && let Some(file_id) = entry.file_id
+                {
+                    return Action::RemoveSymbols(entry.name.clone(), file_id);
                 }
             }
             KeyCode::Char('/') => self.path_input.open(None),

--- a/src/tui/state/flamegraph.rs
+++ b/src/tui/state/flamegraph.rs
@@ -166,10 +166,10 @@ impl FlamegraphTab {
                 .children
                 .len()
         };
-        if let Some(last) = self.cursor_path.last_mut() {
-            if *last + 1 < sibling_count {
-                *last += 1;
-            }
+        if let Some(last) = self.cursor_path.last_mut()
+            && *last + 1 < sibling_count
+        {
+            *last += 1;
         }
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -223,7 +223,7 @@ fn render_waiting(frame: &mut Frame, area: Rect, listen_addr: &str) {
     buf.set_string(
         sep_x,
         base_y + 1,
-        &"─".repeat(sep_len as usize),
+        "─".repeat(sep_len as usize),
         Style::default().fg(SEP_COLOR).bg(BG),
     );
 
@@ -525,16 +525,17 @@ fn render_flamegraph(fg: &mut FlamegraphTab, frame: &mut Frame, area: Rect) {
             }
         }
 
-        if is_cursor && fr.width >= 3 {
-            if let Some(cell) = buf.cell_mut((area.x + fr.x + 1, screen_y)) {
-                cell.set_char('▸');
-                cell.set_style(
-                    Style::default()
-                        .fg(Color::White)
-                        .bg(bg)
-                        .add_modifier(Modifier::BOLD),
-                );
-            }
+        if is_cursor
+            && fr.width >= 3
+            && let Some(cell) = buf.cell_mut((area.x + fr.x + 1, screen_y))
+        {
+            cell.set_char('▸');
+            cell.set_style(
+                Style::default()
+                    .fg(Color::White)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
+            );
         }
     }
 
@@ -677,7 +678,7 @@ fn render_flamescope(fs: &mut FlamescopeTab, frame: &mut Frame, area: Rect) {
             buf.set_string(
                 lay.label_x(),
                 label_y,
-                &format!("{:>3}ms ", lay.ms_label(row)),
+                format!("{:>3}ms ", lay.ms_label(row)),
                 Style::default().fg(DIM),
             );
         }
@@ -862,7 +863,7 @@ fn render_exe_table(exe: &mut ExecutablesTab, frame: &mut Frame, area: Rect) {
         buf.set_string(
             area.x + 1 + col_id_w,
             y,
-            &format!("{prefix}{name}"),
+            format!("{prefix}{name}"),
             name_style,
         );
 
@@ -933,7 +934,7 @@ fn render_overlay(frame: &mut Frame, area: Rect, props: &OverlayProps) {
     buf.set_string(
         popup.x + 1,
         popup.y + 1,
-        &truncate(&prompt, inner_w),
+        truncate(&prompt, inner_w),
         Style::reset().fg(BRIGHT),
     );
 


### PR DESCRIPTION
This should probably be checked in CI for consistency

Basically ran `cargo fmt && cargo clippy`. This is the only lint that I did not fix:

```
warning: very complex type used. Consider factoring parts into `type` definitions
    --> src/tui/ui.rs:1134:17
     |
1134 | const PALETTES: &[&[(f64, (u8, u8, u8))]] = &[
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
     = note: `#[warn(clippy::type_complexity)]` on by default

warning: `eprofiler-tui` (bin "eprofiler-tui") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s
``` 

I ran `rustc 1.94.0 (4a4ef493e 2026-03-02) (built from a source tarball)`